### PR TITLE
CD-94860 Fix Makara adapter error

### DIFF
--- a/lib/activerecord-import/active_record/adapters/mysql2_makara_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/mysql2_makara_adapter.rb
@@ -1,6 +1,6 @@
-require "active_record/connection_adapters/makara_mysql2_adapter"
+require "active_record/connection_adapters/mysql2_adapter"
 require "activerecord-import/adapters/mysql_adapter"
 
-class ActiveRecord::ConnectionAdapters::MakaraMysql2Adapter
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
   include ActiveRecord::Import::MysqlAdapter::InstanceMethods
 end


### PR DESCRIPTION
Since Makara adapter actually uses Mysql2Adapter underneath, I was instrumenting the wrong class.

Tested locally.

- [x] @johnny-lai 